### PR TITLE
ftms encode output and indexes

### DIFF
--- a/src/ble/ftms/control-point.js
+++ b/src/ble/ftms/control-point.js
@@ -3,7 +3,7 @@
 //
 
 import { fixInRange, hex }  from '../../utils.js';
-import {  existance, curry2 }  from '../../functions.js';
+import { existance, curry2 }  from '../../functions.js';
 
 const logs = true;
 
@@ -109,7 +109,7 @@ function ResistanceTarget() {
 
         log(`:tx :ftms :resistance ${args.resistance} -> ${resistance}`);
 
-        return view;
+        return view.buffer;
     }
 
     function decode(dataview) {
@@ -196,10 +196,10 @@ function WheelCircumference(args) {
     };
 
     const values = {
-        2080: '700x19C', 2086: '700x20C', 2096: '700x23C', 2105: '700x25C', 2136: '700x28C',
-	      2146: '700x30C', 2155: '700x32C', 2168: '700x35C', 2180: '700x38C',
-        2200: '700x40C', 2242: '700x45C', 2268: '700x47C',
-        2281: `29"x2.25"`, 2326: `29"x2.3"`, 2750: '',
+        2080: '700x19C', 2086: '700x20C', 2096: '700x23C', 2105: '700x25C', 2136: '700x28C', // 20s
+	      2146: '700x30C', 2155: '700x32C', 2168: '700x35C', 2180: '700x38C',                  // 30s
+        2200: '700x40C', 2242: '700x45C', 2268: '700x47C',                                   // 40s
+        2281: `29"x2.25"`, 2326: `29"x2.3"`, 2750: 'tractor',                                // MTBs
     };
 
     // 700x25C -> 2105 -> [0x12, 0x3A, 0x52] -> [18, 58, 82]
@@ -350,6 +350,7 @@ function Response() {
     }
 
     return Object.freeze({
+        opCode,
         results,
         requests,
         encode,

--- a/src/ble/ftms/indoor-bike-data.js
+++ b/src/ble/ftms/indoor-bike-data.js
@@ -174,7 +174,7 @@ function readHeartRate(dataview) {
 // (10) [68, 2, 170, 5, 46, 0, 24, 0, 70]
 //
 //    "Instantanious Speed: 14.5 km/h
-//     Instantanious Cadence: 24.0 per min
+//     Instantanious Cadence: 23.0 per min
 //     Instantanious Power: 24 W
 //     Heart Rate: 70 bpm"
 //

--- a/src/ble/ftms/supported-ranges.js
+++ b/src/ble/ftms/supported-ranges.js
@@ -26,14 +26,16 @@ function PowerRange() {
         const view   = new DataView(buffer);
 
         view.setUint16(0, min, true);
-        view.setUint16(0, max, true);
-        view.setUint16(0, inc, true);
+        view.setUint16(2, max, true);
+        view.setUint16(4, inc, true);
 
         return view.buffer;
     }
 
     function decode(dataview) {
         // (0x) 00-00-20-03-01-00
+        // (10) [0, 0, 32, 3, 1, 0]
+        // 0, 800, 1
         const min = dataview.getUint16(0, dataview, true);
         const max = dataview.getUint16(2, dataview, true);
         const inc = dataview.getUint16(4, dataview, true);
@@ -60,14 +62,16 @@ function ResistanceRange() {
         const view   = new DataView(buffer);
 
         view.setUint16(0, min, true);
-        view.setUint16(0, max, true);
-        view.setUint16(0, inc, true);
+        view.setUint16(2, max, true);
+        view.setUint16(4, inc, true);
 
         return view.buffer;
     }
 
     function decode(dataview) {
         // (0x) 00-00-E8-03-01-00
+        // (10) [0, 0, 232, 3, 1, 0]
+        // 0, 1000, 1
         const min = dataview.getUint16(0, dataview, true);
         const max = dataview.getUint16(2, dataview, true);
         const inc = dataview.getUint16(4, dataview, true);


### PR DESCRIPTION
- ResistanceTarget.encode used to return view and not ArrayBuffer
- Cadence in example used to be 24 (wrong) it needs to be 23
- supported ranges for Power and Resistance
  - encode had all index at 0 it has to be 0, 2, 4
  - adding more verbose data input examples