### PR TITLE
fix: Update start_url to root

### DIFF
--- a/src/manifest.webmanifest
+++ b/src/manifest.webmanifest
@@ -2,7 +2,7 @@
     "name": "Flux",
     "short_name": "Flux",
     "description": "Cycling Structured Training",
-    "start_url": "/Flux",
+    "start_url": "/",
     "display": "standalone",
     "orientation": "portrait",
     "scope": "/",


### PR DESCRIPTION
👋 

I'd love to use Flux as a PWA (on Windows 11), but I'm finding after installing the Vercel-hosted webapp, it's launching as a 404.

![image](https://github.com/dvmarinoff/Flux/assets/389077/2ff3efec-6d9d-4e14-82d8-1d2e680687b7)

To reproduce:

* Open Flux in a PWA-compatible browser (I'm using MS Edge)
* When prompted, install the app
* Launch the app from a taskbar

The issue looks to be an invalid `start_url`; it attempts to load https://flux-web.vercel.app/Flux, rather than the root https://flux-web.vercel.app