### PR TITLE
reduce duration of Chili Pepper to 30mins

### DIFF
--- a/src/workouts/workouts.js
+++ b/src/workouts/workouts.js
@@ -33,17 +33,17 @@ let workouts = [
     </tags>
     <workout>
         <Warmup Duration="120" PowerLow="0.32" PowerHigh="0.39"/>
-        <SteadyState Duration="60" Power="0.39" Cadence="80"/>
-        <SteadyState Duration="60" Power="0.47" Cadence="90"/>
-        <SteadyState Duration="60" Power="0.55" Cadence="100"/>
-        <SteadyState Duration="60" Power="0.63" Cadence="90"/>
+        <SteadyState Duration="45" Power="0.39" Cadence="80"/>
+        <SteadyState Duration="45" Power="0.47" Cadence="90"/>
+        <SteadyState Duration="45" Power="0.55" Cadence="100"/>
+        <SteadyState Duration="45" Power="0.63" Cadence="90"/>
         <IntervalsT Repeat="2" OnDuration="30" OffDuration="30" OnPower="0.98" OffPower="0.63" Cadence="100" CadenceResting="80"/>
-        <SteadyState Duration="120" Power="0.5" Slope="1"/>
-        <IntervalsT Repeat="10" OnDuration="40" OffDuration="20" OnPower="1.21" OffPower="0.44" OnSlope="4" OffSlope="0" Cadence="90" CadenceResting="80"/>
-        <SteadyState Duration="300" Power="0.40" Slope="1"/>
-        <IntervalsT Repeat="10" OnDuration="40" OffDuration="20" OnPower="1.21" OffPower="0.44" OnSlope="4" OffSlope="0"/>
-        <SteadyState Duration="300" Power="0.40"/>
-        <Cooldown Duration="300" PowerLow="0.39" PowerHigh="0.32" />
+        <SteadyState Duration="90" Power="0.5" Slope="1"/>
+        <IntervalsT Repeat="6" OnDuration="40" OffDuration="20" OnPower="1.21" OffPower="0.44" OnSlope="4" OffSlope="0" Cadence="90" CadenceResting="80"/>
+        <SteadyState Duration="180" Power="0.40" Slope="1"/>
+        <IntervalsT Repeat="6" OnDuration="40" OffDuration="20" OnPower="1.21" OffPower="0.44" OnSlope="4" OffSlope="0"/>
+        <SteadyState Duration="180" Power="0.40"/>
+        <Cooldown Duration="210" PowerLow="0.39" PowerHigh="0.32" />
     </workout>
 </workout_file>
 `,


### PR DESCRIPTION
As per the discussion in [this issue](https://github.com/dvmarinoff/Auuki/issues/271), this PR reduces the duration of the Chili Peppers workout from ~45mins to 30mins by reducing the duration of the individual intervals and the number of repetitions of the intervals.

Happy to discuss + iterate.