### PR TITLE
Introduce more shorter workouts

### DIFF
--- a/src/workouts/workouts.js
+++ b/src/workouts/workouts.js
@@ -110,6 +110,129 @@ let workouts = [
 </workout_file>
 `,
 `<workout_file>
+    <author>Auuki</author>
+    <name>Quiche</name>
+    <category>HIIT</category>
+    <description>This workout features three 6-minute intervals that train your body to better manage and tolerate lactate buildup. You'll begin 'at' your FTP, increase to Zone 5 intensity (over), then finish with a Zone 3 effort (under).</description>
+    <sportType>bike</sportType>
+    <tags>
+    </tags>
+    <workout>
+        <Warmup Duration="300" PowerLow="0.25" PowerHigh="0.966"/>
+        <SteadyState Duration="120" Power="0.5"/>
+        <SteadyState Duration="120" Power="0.901"/>
+        <SteadyState Duration="120" Power="1.053"/>
+        <SteadyState Duration="120" Power="0.763"/>
+        <SteadyState Duration="120" Power="0.5"/>
+        <SteadyState Duration="120" Power="0.901"/>
+        <SteadyState Duration="120" Power="1.053"/>
+        <SteadyState Duration="120" Power="0.763"/>
+        <SteadyState Duration="120" Power="0.5"/>
+        <SteadyState Duration="120" Power="0.901"/>
+        <SteadyState Duration="120" Power="1.053"/>
+        <SteadyState Duration="120" Power="0.763"/>
+        <SteadyState Duration="120" Power="0.5"/>
+        <Cooldown Duration="180" PowerLow="0.75" PowerHigh="0.25"/>
+    </workout>
+</workout_file>`
+,
+`<workout_file>
+    <author>Auuki</author>
+    <name>Quiche +1</name>
+    <category>HIIT</category>
+    <description>This workout features two sets with 5 intervals each that train your body to better manage and tolerate lactate buildup. You'll begin 'at' your FTP, increase to Zone 5 intensity (over), then finish with a Zone 3 effort (under).</description>
+    <sportType>bike</sportType>
+    <tags>
+    </tags>
+    <workout>
+        <Warmup Duration="300" PowerLow="0.25" PowerHigh="0.966"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="180" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <SteadyState Duration="45" Power="0.901"/>
+        <SteadyState Duration="45" Power="1.053"/>
+        <SteadyState Duration="45" Power="0.763"/>
+        <SteadyState Duration="60" Power="0.5"/>
+        <Cooldown Duration="270" PowerLow="0.75" PowerHigh="0.25"/>
+    </workout>
+</workout_file>`
+,
+`<workout_file>
+    <author>Auuki</author>
+    <name>Salad</name>
+    <category>HIIT</category>
+    <description>This workout uses pyramid-structured intervals that gradually build up to your FTP threshold. These efforts enhance your body's capacity to metabolize exercise byproducts—such as lactate and convert them into usable fuel for your cardiovascular system.</description>
+    <sportType>bike</sportType>
+    <tags>
+    </tags>
+    <workout>
+        <SteadyState Duration="90" Power="0.604"/>
+        <SteadyState Duration="90" Power="0.704"/>
+        <SteadyState Duration="90" Power="0.814"/>
+        <SteadyState Duration="90" Power="0.904"/>
+        <SteadyState Duration="60" Power="0.504"/>
+        <SteadyState Duration="45" Power="1.054"/>
+        <SteadyState Duration="60" Power="0.604"/>
+        <SteadyState Duration="45" Power="1.104"/>
+        <SteadyState Duration="60" Power="0.554"/>
+        <SteadyState Duration="45" Power="1.154"/>
+        <SteadyState Duration="60" Power="0.504"/>
+        <SteadyState Duration="120" Power="0.654"/>
+        <SteadyState Duration="120" Power="0.814"/>
+        <SteadyState Duration="120" Power="0.884"/>
+        <SteadyState Duration="45" Power="1.004"/>
+        <SteadyState Duration="90" Power="0.654"/>
+        <SteadyState Duration="45" Power="1.004"/>
+        <SteadyState Duration="120" Power="0.884"/>
+        <SteadyState Duration="120" Power="0.814"/>
+        <SteadyState Duration="120" Power="0.504"/>
+        <SteadyState Duration="125" Power="0.814"/>
+        <SteadyState Duration="120" Power="0.884"/>
+        <SteadyState Duration="45" Power="1.004"/>
+        <SteadyState Duration="90" Power="0.654"/>
+        <SteadyState Duration="45" Power="1.004"/>
+        <SteadyState Duration="120" Power="0.884"/>
+        <SteadyState Duration="120" Power="0.814"/>
+        <SteadyState Duration="120" Power="0.504"/>
+        <Cooldown Duration="280" PowerLow="0.754" PowerHigh="0.504"/>
+    </workout>
+</workout_file>`
+,
+`<workout_file>
     <author>Marinov</author>
     <name>Pasta</name>
     <category>Threshold</category>
@@ -353,126 +476,6 @@ let workouts = [
         <SteadyState Duration="60" Power="2.02" />
     </workout>
 </workout_file>`,
-`<workout_file>
-    <author>Auuki</author>
-    <name>Quiche</name>
-    <category>HIIT</category>
-    <description>This workout features three 6-minute intervals that train your body to better manage and tolerate lactate buildup. You'll begin 'at' your FTP, increase to Zone 5 intensity (over), then finish with a Zone 3 effort (under).</description>
-    <sportType>bike</sportType>
-    <tags>
-    </tags>
-    <workout>
-        <Warmup Duration="300" PowerLow="0.25" PowerHigh="0.966"/>
-        <SteadyState Duration="120" Power="0.5"/>
-        <SteadyState Duration="120" Power="0.901"/>
-        <SteadyState Duration="120" Power="1.053"/>
-        <SteadyState Duration="120" Power="0.763"/>
-        <SteadyState Duration="120" Power="0.5"/>
-        <SteadyState Duration="120" Power="0.901"/>
-        <SteadyState Duration="120" Power="1.053"/>
-        <SteadyState Duration="120" Power="0.763"/>
-        <SteadyState Duration="120" Power="0.5"/>
-        <SteadyState Duration="120" Power="0.901"/>
-        <SteadyState Duration="120" Power="1.053"/>
-        <SteadyState Duration="120" Power="0.763"/>
-        <SteadyState Duration="120" Power="0.5"/>
-        <Cooldown Duration="180" PowerLow="0.75" PowerHigh="0.25"/>
-    </workout>
-</workout_file>`,
-`<workout_file>
-    <author>Auuki</author>
-    <name>Quiche +1</name>
-    <category>HIIT</category>
-    <description>This workout features two sets with 5 intervals each that train your body to better manage and tolerate lactate buildup. You'll begin 'at' your FTP, increase to Zone 5 intensity (over), then finish with a Zone 3 effort (under).</description>
-    <sportType>bike</sportType>
-    <tags>
-    </tags>
-    <workout>
-        <Warmup Duration="300" PowerLow="0.25" PowerHigh="0.966"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="180" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <SteadyState Duration="45" Power="0.901"/>
-        <SteadyState Duration="45" Power="1.053"/>
-        <SteadyState Duration="45" Power="0.763"/>
-        <SteadyState Duration="60" Power="0.5"/>
-        <Cooldown Duration="270" PowerLow="0.75" PowerHigh="0.25"/>
-    </workout>
-</workout_file>`,
-`<workout_file>
-    <author>Auuki</author>
-    <name>Salad</name>
-    <category>HIIT</category>
-    <description>This workout uses pyramid-structured intervals that gradually build up to your FTP threshold. These efforts enhance your body's capacity to metabolize exercise byproducts—such as lactate and convert them into usable fuel for your cardiovascular system.</description>
-    <sportType>bike</sportType>
-    <tags>
-    </tags>
-    <workout>
-        <SteadyState Duration="90" Power="0.604"/>
-        <SteadyState Duration="90" Power="0.704"/>
-        <SteadyState Duration="90" Power="0.814"/>
-        <SteadyState Duration="90" Power="0.904"/>
-        <SteadyState Duration="60" Power="0.504"/>
-        <SteadyState Duration="45" Power="1.054"/>
-        <SteadyState Duration="60" Power="0.604"/>
-        <SteadyState Duration="45" Power="1.104"/>
-        <SteadyState Duration="60" Power="0.554"/>
-        <SteadyState Duration="45" Power="1.154"/>
-        <SteadyState Duration="60" Power="0.504"/>
-        <SteadyState Duration="120" Power="0.654"/>
-        <SteadyState Duration="120" Power="0.814"/>
-        <SteadyState Duration="120" Power="0.884"/>
-        <SteadyState Duration="45" Power="1.004"/>
-        <SteadyState Duration="90" Power="0.654"/>
-        <SteadyState Duration="45" Power="1.004"/>
-        <SteadyState Duration="120" Power="0.884"/>
-        <SteadyState Duration="120" Power="0.814"/>
-        <SteadyState Duration="120" Power="0.504"/>
-        <SteadyState Duration="125" Power="0.814"/>
-        <SteadyState Duration="120" Power="0.884"/>
-        <SteadyState Duration="45" Power="1.004"/>
-        <SteadyState Duration="90" Power="0.654"/>
-        <SteadyState Duration="45" Power="1.004"/>
-        <SteadyState Duration="120" Power="0.884"/>
-        <SteadyState Duration="120" Power="0.814"/>
-        <SteadyState Duration="120" Power="0.504"/>
-        <Cooldown Duration="280" PowerLow="0.754" PowerHigh="0.504"/>
-    </workout>
-</workout_file>`
 ];
 
 export { workouts };


### PR DESCRIPTION
As per the discussion in https://github.com/dvmarinoff/Auuki/issues/271 I'm proposing three new workouts:
1. **At/Over/Under x3** ([editor](https://www.zwiftworkout.com/editor/mjj13ovvjm))
<img height="200" alt="Screenshot 2025-10-09 at 21 22 00" src="https://github.com/user-attachments/assets/fb8d9185-b4d8-4c98-966a-ddab9d54cb9d" />

2. **At/Over/Under x2x5** ([editor](https://www.zwiftworkout.com/editor/uxrmnan8q4))
<img height="200" alt="Screenshot 2025-10-09 at 21 22 08" src="https://github.com/user-attachments/assets/4cef1d23-81b5-426e-b16f-45b53bd49009" />

3. **Power Builder** ([editor](https://www.zwiftworkout.com/editor/s380gg71acj))
<img height="200" alt="Screenshot 2025-10-09 at 21 22 12" src="https://github.com/user-attachments/assets/4fd03eec-4134-41df-aec2-eaa9ad7251c8" />

As I don't know for how long the editor (zwiftworkout.com) will save such workouts, I also added some screenshots for easier interpretation of the workouts.

After adding them to your file, I uploaded them to the editor to verify the xml is well-formatted.

While adding these workouts, I came up with the following question, which we could discuss:
1. What about the naming of the workouts? Does it fit your naming scheme?
2. What about the position of the workouts in the list of other workouts? Should we move them?

Happy to discuss anything else.