### PR TITLE
add Start in Dock Mode setting

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -62,6 +62,7 @@ let db = {
     ftp: models.ftp.default,
     weight: models.weight.default,
     theme: models.theme.default,
+    dockMode: models.dockMode.default,
     measurement: models.measurement.default,
     volume: models.volume.default,
 
@@ -163,6 +164,11 @@ xf.reg(models.sources.prop, (sources, db) => {
     db.sources = models.sources.set(db.sources, sources);
     models.sources.backup(db.sources);
     console.log(db.sources);
+});
+
+xf.reg(models.dockMode.prop, (value, db) => {
+    db.dockMode = models.dockMode.set(value);
+    models.dockMode.backup(db.dockMode);
 });
 
 xf.reg('power1s', (power, db) => {
@@ -286,6 +292,11 @@ xf.reg('ui:theme-switch', (_, db) => {
     db.theme = models.theme.switch(db.theme);
     models.theme.backup(db.theme);
 });
+
+xf.reg('ui:dock-mode-switch', (_, db) => {
+    db.theme = models.dockMode.switch(db.dockMode);
+    models.dockMode.backup(db.dockMode);
+});
 xf.reg('ui:measurement-switch', (_, db) => {
     db.measurement = models.measurement.switch(db.measurement);
     models.measurement.backup(db.measurement);
@@ -395,6 +406,9 @@ xf.reg('services', (x, db) => {
 
 //
 xf.reg('app:start', async function(_, db) {
+
+    db.dockMode = models.dockMode.set(models.dockMode.restore());
+    models.dockMode.apply(db.dockMode);
 
     db.ftp = models.ftp.set(models.ftp.restore());
     db.weight = models.weight.set(models.weight.restore());

--- a/src/index.html
+++ b/src/index.html
@@ -1457,6 +1457,15 @@
                                 </theme-layout>
                             </div>
                         </div>
+
+                        <div class="list--row--outer">
+                            <div class="list--row--inner option">
+                                <div class="option--name">Start in Dock Mode</div>
+                                <dock-mode-default class="option--value">
+                                    OFF
+                                </dock-mode-default>
+                            </div>
+                        </div>
                     </div> <!-- END Options -->
 
                     <!-- about -->

--- a/src/models/models.js
+++ b/src/models/models.js
@@ -464,6 +464,50 @@ class Theme extends Model {
         return self.default;
     }
 }
+
+class DockMode extends Model {
+    postInit(args = {}) {
+        const self = this;
+        const storageModel = {
+            key: self.prop,
+            fallback: self.defaultValue(),
+            parse: (x) => x === 'true',
+        };
+        self.storage = new args.storage(storageModel);
+        self.values = [true, false];
+    }
+    defaultValue() { return false; }
+    switch(state) {
+        return !state;
+    }
+    apply(state) {
+        const self = this;
+        if(state && window.innerHeight > 200) {
+            self.resize();
+        }
+    }
+    calcSize() {
+        const width = window.screen.availWidth;
+        const height = 150;
+        const top = window.screen.availHeight - height;
+        return {width: width, height: height, top: top};
+    }
+    resize() {
+        const self = this;
+        let {width, height, top} = self.calcSize();
+        window.resizeTo(width, height);
+        window.moveTo(0, top);
+    }
+    open() {
+        const href = document.location.href;
+        let self = this;
+        let { width, height, top } = self.calcSize();
+
+        window.open(`${href}`, '', `width=${width},height=${height},left=0,top=${top}`);
+        window.close();
+    }
+}
+
 class Measurement extends Model {
     postInit(args = {}) {
         const self = this;
@@ -501,7 +545,6 @@ class DataTileSwitch extends Model {
         return parseInt(value);
     }
 }
-
 
 class Activity extends Model {
     // var activity = {
@@ -1546,6 +1589,7 @@ const page = new Page({prop: 'page'});
 const ftp = new FTP({prop: 'ftp', storage: LocalStorageItem});
 const weight = new Weight({prop: 'weight', storage: LocalStorageItem});
 const theme = new Theme({prop: 'theme', storage: LocalStorageItem});
+const dockMode = new DockMode({prop: 'dockMode', storage: LocalStorageItem});
 const volume = new Volume({prop: 'volume', storage: LocalStorageItem});
 const measurement = new Measurement({prop: 'measurement', storage: LocalStorageItem});
 const dataTileSwitch = new DataTileSwitch({prop: 'dataTileSwitch', storage: LocalStorageItem});
@@ -1594,6 +1638,7 @@ let models = {
     page,
     ftp,
     weight,
+    dockMode,
     volume,
     theme,
     measurement,

--- a/src/views/data-views.js
+++ b/src/views/data-views.js
@@ -1713,18 +1713,45 @@ class Theme extends DataView {
 
 customElements.define('theme-layout', Theme);
 
+class DockModeDefault extends DataView {
+    postInit() {
+        this.effect  = 'dockMode';
+        this.state   = false;
+    }
+    getDefaults() {
+        return {
+            prop: 'db:dockMode',
+            effect: 'dockMode'
+        };
+    }
+    subs() {
+        xf.sub(`${this.prop}`, this.onUpdate.bind(this), this.signal);
+        this.addEventListener('pointerup', this.onEffect.bind(this), this.signal);
+    }
+    onUpdate(value) {
+        this.state = value;
+        this.render();
+    }
+    onEffect() {
+        if(equals(this.state, true)) {
+            xf.dispatch(`${this.effect}`, false);
+        } else {
+            xf.dispatch(`${this.effect}`, true);
+        }
+    }
+    render() {
+        this.textContent = equals(this.state, true) ? 'ON' : 'OFF';
+    }
+}
+
+customElements.define('dock-mode-default', DockModeDefault);
+
 class DockModeBtn extends DataView {
     subs() {
         this.addEventListener('pointerup', this.onSwitch.bind(this), this.signal);
     }
     onSwitch() {
-        const href = document.location.href;
-        const width = window.screen.availWidth;
-        const height = 150;
-        const top = 0; // window.screen.availHeight - height;
-
-        // window.resizeTo(width, height);
-        window.open(`${href}`, '', `width=${width},height=${height},left=0,top=${top}`);
+        models.dockMode.open();
     }
 }
 


### PR DESCRIPTION
- Start in Dock mode can be ON or OFF
- This has effect only if the app is running in Standalone mode when installed
- if the value is ON the app will try to resize to dock mode
- if the value is OFF the app will start with its previous size
- the setting is stored in Local Storage not in Sources

- The Dock Button will now put the Dock Window at the bottom not at the top, and will try to close the original window

NOTE: may work on Linux and Windows, on Mac the window is restricted to 250px height when using the `window.resizeTo` or manual drag resize