### PR TITLE
fix: Workout step tooltip not appearing or flickering

### DIFF
--- a/src/css/flux.css
+++ b/src/css/flux.css
@@ -910,6 +910,7 @@ div.graph--bar-group {
     background-color: var(--white);
     border-radius: 0.2em;
     z-index: 2;
+    pointer-events: none;
 }
 
 /* #graph-moxy { */


### PR DESCRIPTION
When using mouse to hover over the workout graph to view details of individual steps, the tooltip would sometimes fail to appear or it would flicker. The cause seemed to be pointer events triggering on the tooltip once shown, causing it to be incorrectly hidden. Setting `pointer-events: none` fixes the issue.

Before:
![auuki-tooltip-broken](https://github.com/user-attachments/assets/be7cf04c-b3a1-449b-b46a-d22565365cf8)

After:
![auuki-tooltip-fixed](https://github.com/user-attachments/assets/824a9b52-2659-473f-8809-f4ea1e571bbd)
