### PR TITLE
Load workout URL param at startup

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -337,6 +337,23 @@ xf.reg('ui:workout:upload', async function(files, db) {
     }
 
 });
+xf.reg('ui:workout:load-url', async function(workoutUrl, db) {
+    try {
+        const response = await fetch(workoutUrl);
+        if(!response.ok) {
+            throw new Error(`Failed to fetch workout: ${response.status}`);
+        }
+        const result = await response.text();
+        const name = workoutUrl.split('/').pop() || 'workout.zwo';
+        const workout = models.workout.parse(result, name);
+        models.workouts.add(db.workouts, workout);
+        xf.dispatch('db:workouts', db);
+        xf.dispatch('ui:workout:select', workout.id);
+        xf.dispatch('ui:page-set', 'home');
+    } catch (e) {
+        console.error(`:ui :workout :load-url :error`, e);
+    }
+});
 xf.reg('watch:stopped', (_, db) => {
     try {
         models.activity.createFromCurrent(db);
@@ -470,4 +487,3 @@ function start () {
 start();
 
 export { db };
-

--- a/src/models/api.js
+++ b/src/models/api.js
@@ -69,6 +69,7 @@ function Router(args = {}) {
         const scope  = params.get('scope');
         const error  = params.get('error');
         const token = params.get('token');
+        const workoutUrl = params.get('workoutUrl');
 
         // switch
         if(error) {
@@ -96,6 +97,11 @@ function Router(args = {}) {
             xf.dispatch('action:auth', ':password:reset');
             return true;
         }
+        if(workoutUrl) {
+            xf.dispatch('ui:workout:load-url', workoutUrl);
+            clearParams();
+            return true;
+        }
         // clearParams();
         return false;
     }
@@ -113,4 +119,3 @@ function Router(args = {}) {
 
 
 export default API;
-


### PR DESCRIPTION
Enable direct workout imports from external ZWO URLs so users can deep-link into Auuki without manual file uploads and immediately begin riding.

e.g. given a URL pointing to a ZWO file, say http://my-app.com/threshold-intervals.zwo, then that workout can be loaded and ready to go in Auuki like so (in dev, i.e. localhost):

http://localhost:1234?workoutUrl=http%3A%2F%2Fmy-app.com%2Fthreshold-intervals.zwo

This saves manually downloading (from URL), and in Auuki loading, selecting and navigating to the workout.

This change relies on the remote endpoint hosting the ZWO allowing cross-origin fetches.
